### PR TITLE
Channel buffer size

### DIFF
--- a/lib/firehose/client/producer.rb
+++ b/lib/firehose/client/producer.rb
@@ -42,8 +42,9 @@ module Firehose
 
         # Publish the message via HTTP.
         def put(message, channel, opts, &block)
-          ttl = opts[:ttl]
-          timeout = opts[:timeout] || @timeout || DEFAULT_TIMEOUT
+          ttl         = opts[:ttl]
+          timeout     = opts[:timeout] || @timeout || DEFAULT_TIMEOUT
+          buffer_size = opts[:buffer_size]
 
           response = conn.put do |req|
             req.options[:timeout] = timeout
@@ -60,6 +61,7 @@ module Firehose
             end
             req.body = message
             req.headers['Cache-Control'] = "max-age=#{ttl.to_i}" if ttl
+            req.params[:buffer_size] = buffer_size if buffer_size
           end
           response.on_complete do
             case response.status

--- a/lib/firehose/client/producer.rb
+++ b/lib/firehose/client/producer.rb
@@ -61,7 +61,7 @@ module Firehose
             end
             req.body = message
             req.headers['Cache-Control'] = "max-age=#{ttl.to_i}" if ttl
-            req.params[:buffer_size] = buffer_size if buffer_size
+            req.headers["X-Firehose-Buffer-Size"] = buffer_size if buffer_size
           end
           response.on_complete do
             case response.status

--- a/lib/firehose/client/producer.rb
+++ b/lib/firehose/client/producer.rb
@@ -61,7 +61,7 @@ module Firehose
             end
             req.body = message
             req.headers['Cache-Control'] = "max-age=#{ttl.to_i}" if ttl
-            req.headers["X-Firehose-Buffer-Size"] = buffer_size if buffer_size
+            req.headers["X-Firehose-Buffer-Size"] = buffer_size.to_s if buffer_size
           end
           response.on_complete do
             case response.status

--- a/lib/firehose/rack/publisher.rb
+++ b/lib/firehose/rack/publisher.rb
@@ -10,7 +10,6 @@ module Firehose
         path          = req.path
         method        = req.request_method
         cache_control = {}
-        params        = ::Rack::Utils.parse_query(env["QUERY_STRING"])
 
         # Parse out cache control directives from the Cache-Control header.
         if cache_control_header = env['HTTP_CACHE_CONTROL']
@@ -30,7 +29,7 @@ module Firehose
             body = env['rack.input'].read
             Firehose.logger.debug "HTTP published #{body.inspect} to #{path.inspect} with ttl #{ttl.inspect}"
             opts = { :ttl => ttl }
-            if buffer_size = params["buffer_size"]
+            if buffer_size = env["HTTP_X_FIREHOSE_BUFFER_SIZE"]
               opts[:buffer_size] = buffer_size.to_i
             end
             publisher.publish(path, body, opts).callback do

--- a/spec/integrations/shared_examples.rb
+++ b/spec/integrations/shared_examples.rb
@@ -41,7 +41,7 @@ shared_examples_for 'Firehose::Rack::App' do
 
     # Setup a publisher
     publish = Proc.new do
-      Firehose::Client::Producer::Http.new.publish(outgoing.shift).to(channel) do
+      Firehose::Client::Producer::Http.new.publish(outgoing.shift).to(channel, buffer_size: rand(100)) do
         # The random timer ensures that sometimes the clients will be behind
         # and sometimes they will be caught up.
         EM::add_timer(rand*0.005) { publish.call } unless outgoing.empty?

--- a/spec/lib/server/publisher_spec.rb
+++ b/spec/lib/server/publisher_spec.rb
@@ -7,8 +7,8 @@ describe Firehose::Server::Publisher do
   let(:channel_key) { "/firehose/publisher/test/#{Time.now.to_i}" }
   let(:message)     { "howdy friends!" }
 
-  it "has 100 MAX_MESSAGES" do
-    expect(Firehose::Server::Publisher::MAX_MESSAGES).to eql(100)
+  it "has 100 BUFFER_SIZE" do
+    expect(Firehose::Server::Publisher::BUFFER_SIZE).to eql(100)
   end
 
   it "has 1 day TTL" do
@@ -45,14 +45,14 @@ describe Firehose::Server::Publisher do
       expect(redis_exec('lpop', "firehose:#{channel_key}:list")).to eql(message)
     end
 
-    it "limits list to MAX_MESSAGES messages" do
+    it "limits list to BUFFER_SIZE messages" do
       em do
-        Firehose::Server::Publisher::MAX_MESSAGES.times do |n|
+        Firehose::Server::Publisher::BUFFER_SIZE.times do |n|
           publisher.publish(channel_key, message)
         end
         publisher.publish(channel_key, message).callback { em.stop }
       end
-      expect(redis_exec('llen', "firehose:#{channel_key}:list")).to eql(Firehose::Server::Publisher::MAX_MESSAGES)
+      expect(redis_exec('llen', "firehose:#{channel_key}:list")).to eql(Firehose::Server::Publisher::BUFFER_SIZE)
     end
 
     it "increments sequence" do

--- a/spec/lib/server/publisher_spec.rb
+++ b/spec/lib/server/publisher_spec.rb
@@ -55,6 +55,17 @@ describe Firehose::Server::Publisher do
       expect(redis_exec('llen', "firehose:#{channel_key}:list")).to eql(Firehose::Server::Publisher::BUFFER_SIZE)
     end
 
+    it "limits message list to a custom buffer size" do
+      buffer_size = rand(100)
+      em do
+        Firehose::Server::Publisher::BUFFER_SIZE.times do |n|
+          publisher.publish(channel_key, message)
+        end
+        publisher.publish(channel_key, message, buffer_size: buffer_size).callback { em.stop }
+      end
+      redis_exec('llen', "firehose:#{channel_key}:list").should == buffer_size
+    end
+
     it "increments sequence" do
       sequence_key = "firehose:#{channel_key}:sequence"
 


### PR DESCRIPTION
Add support for per-channel buffer sizes.
When no buffer size has been set by a publisher, the default buffer size (100) is used.
Also renamed MAX_MESSAGES => BUFFER_SIZE for clarity.

This implements #35.