### PR TITLE
Better return codes

### DIFF
--- a/lib/firehose/rack/consumer.rb
+++ b/lib/firehose/rack/consumer.rb
@@ -13,7 +13,7 @@ module Firehose
       MULTIPLEX_CHANNEL = "channels@firehose"
 
       def self.multiplexing_request?(env)
-        env["REQUEST_PATH"].include? MULTIPLEX_CHANNEL
+        env["PATH_INFO"].include? MULTIPLEX_CHANNEL
       end
 
       def self.multiplex_subscriptions(env)

--- a/lib/firehose/rack/consumer/http_long_poll.rb
+++ b/lib/firehose/rack/consumer/http_long_poll.rb
@@ -34,7 +34,8 @@ module Firehose
           def call(env)
             request = request(env)
 
-            case request.request_method
+            method = request.request_method
+            case method
             # GET is how clients subscribe to the queue. When a messages comes in, we flush out a response,
             # close down the requeust, and the client then reconnects.
             when 'GET'

--- a/lib/firehose/rack/consumer/http_long_poll.rb
+++ b/lib/firehose/rack/consumer/http_long_poll.rb
@@ -46,7 +46,7 @@ module Firehose
 
             else
               Firehose.logger.debug "HTTP #{method} not supported"
-              response(501, "#{method} not supported.")
+              response(405, "#{method} not supported.", "Allow" => "GET")
             end
           end
 

--- a/spec/lib/rack/consumer/http_long_poll_spec.rb
+++ b/spec/lib/rack/consumer/http_long_poll_spec.rb
@@ -1,12 +1,30 @@
 require 'spec_helper'
+require 'rack/test'
+require 'async_rack_test'
 
 describe Firehose::Rack::Consumer::HttpLongPoll do
+  include AsyncRackTest::Methods
+  let(:app) { Firehose::Rack::Consumer::HttpLongPoll.new }
+
   context "transport" do
     # Transport for Firehose::Rack::App class is tested via the spec/integrations suite.
   end
   context "configuration" do
     it "has #timeout" do
       expect(Firehose::Rack::Consumer::HttpLongPoll.new(200).timeout).to eql(200)
+    end
+  end
+
+  context "POST request" do
+    before do
+      post "/blah"
+    end
+    it "returns 405 for POST" do
+      expect(last_response.status).to eql(405)
+    end
+
+    it "specifies GET in the Allow header" do
+      expect(last_response.headers["Allow"]).to eql("GET")
     end
   end
 end


### PR DESCRIPTION
A few semi-related changes.

Returns a 405 when someone POSTs to an endpoint that only supports GET. Before this an exception would be raised.

The other change was needed to make the new tests pass. But it seems to be the "right" thing to do anyway.